### PR TITLE
Using the public repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/awslabs/PRIVATE-aws-vsts-extensions"
+        "url": "https://github.com/aws/aws-vsts-tools"
     },
     "keywords": [
         "AWS",


### PR DESCRIPTION
The current repo url is not getting detected by the marketplace so the github links are not getting generated.