### PR TITLE
Set isConfidential to false for Access Key ID

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -146,6 +146,7 @@
                                 "name": "Access Key ID",
                                 "description": "The AWS access key ID for signing programmatic requests.\nExample: AKIAIOSFODNN7EXAMPLE",
                                 "inputMode": "textbox",
+                                "isConfidential": false,
                                 "validation": {
                                     "isRequired": true,
                                     "dataType": "string"


### PR DESCRIPTION
This property seems to default to true. Having the access key ID visible via the VSTS API simplifies key management/rotation.