### PR TITLE
Revert "Set isConfidential to false for Access Key ID"

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -146,7 +146,6 @@
                                 "name": "Access Key ID",
                                 "description": "The AWS access key ID for signing programmatic requests.\nExample: AKIAIOSFODNN7EXAMPLE",
                                 "inputMode": "textbox",
-                                "isConfidential": false,
                                 "validation": {
                                     "isRequired": true,
                                     "dataType": "string"


### PR DESCRIPTION
Reverts aws/aws-vsts-tools#30

Testing appears to show existing endpoint data is discarded when a new version of the extension is uploaded.