### PR TITLE
Revert "Revert "Set isConfidential to false for Access Key ID""

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -146,6 +146,7 @@
                                 "name": "Access Key ID",
                                 "description": "The AWS access key ID for signing programmatic requests.\nExample: AKIAIOSFODNN7EXAMPLE",
                                 "inputMode": "textbox",
+                                "isConfidential": false,
                                 "validation": {
                                     "isRequired": true,
                                     "dataType": "string"


### PR DESCRIPTION
Reverts aws/aws-vsts-tools#31

Completed testing across a number of VSTS and on-premise TFS accounts and verified that the loss of data issue was a false alarm. Re-instating the original contribution from [cameronattard](https://github.com/cameronattard)