### PR TITLE
Conditionally set ExternalId when length > 0

### DIFF
--- a/Tasks/Common/sdkutils/sdkutils.ts
+++ b/Tasks/Common/sdkutils/sdkutils.ts
@@ -97,9 +97,11 @@ export abstract class AWSTaskParametersBase {
             const options: STS.AssumeRoleRequest = {
                 RoleArn: this.AssumeRoleARN,
                 DurationSeconds: duration,
-                RoleSessionName: roleSessionName,
-                ExternalId: externalId
+                RoleSessionName: roleSessionName
             };
+            if (externalId) {
+                options.ExternalId = externalId;
+            }
 
             this.Credentials = new AWS.TemporaryCredentials(options, masterCredentials);
         }


### PR DESCRIPTION
When assuming a role and no ExternalId is set, I get the following error from the AWSCLI task:
`##[error]1 validation error detected: Value '' at 'externalId' failed to satisfy constraint: Member must have length greater than or equal to 2`.

This is just a suggested solution - unfortunately I haven't been able to test this as I've had trouble getting the project to build/package.