### PR TITLE
feat: allow use of yaml for cloudformation stack params

### DIFF
--- a/Tasks/CloudFormationCreateOrUpdateStack/helpers/CreateOrUpdateStackTaskOperations.ts
+++ b/Tasks/CloudFormationCreateOrUpdateStack/helpers/CreateOrUpdateStackTaskOperations.ts
@@ -9,6 +9,7 @@
 import tl = require('vsts-task-lib/task');
 import path = require('path');
 import fs = require('fs');
+import yaml = require('js-yaml');
 import CloudFormation = require('aws-sdk/clients/cloudformation');
 import S3 = require('aws-sdk/clients/s3');
 import Parameters = require('./CreateOrUpdateStackTaskParameters');
@@ -463,7 +464,16 @@ export class TaskOperations {
         }
 
         try {
-            const templateParameters = JSON.parse(fs.readFileSync(parametersFile, 'utf8'));
+            let templateParameters;
+            try {
+                templateParameters = JSON.parse(fs.readFileSync(parametersFile, 'utf8'));
+            } catch (err) {
+                try {
+                    templateParameters = yaml.safeLoad(fs.readFileSync(parametersFile, 'utf8'));
+                } catch (errorYamlLoad) {
+                    throw err;
+                }
+            }
             tl.debug('Successfully loaded template parameters file');
             return templateParameters;
         } catch (err) {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "aws-sdk": "2.188.0",
         "base-64": "0.1.0",
         "https-proxy-agent": "2.1.0",
+        "js-yaml": "3.10.0",
         "shelljs": "0.7.8",
         "vsts-task-lib": "2.0.6"
     }


### PR DESCRIPTION
Following discussion from issue https://github.com/aws/aws-vsts-tools/issues/68

Here is the most naive implementation of this feature to allow use of Yaml format for parameters files of cloud formation