### PR TITLE
Feature - Ability to provide stack creation wait timeout

### DIFF
--- a/Tasks/CloudFormationCreateOrUpdateStack/helpers/CreateOrUpdateStackTaskParameters.ts
+++ b/Tasks/CloudFormationCreateOrUpdateStack/helpers/CreateOrUpdateStackTaskParameters.ts
@@ -47,6 +47,7 @@ export class TaskParameters extends sdkutils.AWSTaskParametersBase {
 
     public onFailure: string;
     public outputVariable: string;
+    public stackCreateWaitTimout: number;
 
     constructor() {
         super();
@@ -134,6 +135,7 @@ export class TaskParameters extends sdkutils.AWSTaskParametersBase {
 
             this.onFailure = tl.getInput('onFailure');
             this.outputVariable = tl.getInput('outputVariable', false);
+            this.stackCreateWaitTimout = Number(tl.getInput('stackCreateWaitTimout', false)) || 1;
         } catch (error) {
             throw new Error(error.message);
         }

--- a/Tasks/CloudFormationCreateOrUpdateStack/task.json
+++ b/Tasks/CloudFormationCreateOrUpdateStack/task.json
@@ -303,6 +303,15 @@
             "required": false
         },
         {
+            "name": "stackCreateWaitTimout",
+            "type": "string",
+            "label": "Stack Create Wait Timeout (in hours)",
+            "defaultValue": "1",
+            "groupName": "Options",
+            "helpMarkDown": "Wait timeout (in hours) until stack status is CREATE_COMPLETE.",
+            "required": false
+        },
+        {
             "name": "logRequest",
             "type": "boolean",
             "label": "Log Request",


### PR DESCRIPTION
Hi,

This PR is related to issue #85 where the cloudformation.[waitFor](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudFormation.html#stackCreateComplete-waiter) function times out after 60 minutes in 'AWS CloudFormation Create/Update Stack' VSTS task.

I have added a new task parameter (Stack Creation Wait Timeout) to the VSTS task where the user can provide the timeout value in hours. Getting the timeout value in hours instead of minutes allows us to call the 'waitFor' function in a loop. An exception is thrown if the stack creation is not complete in the final iteration of the loop. The default value for the task parameter is 1.