### PR TITLE
Feature - Ability to allow for a custom timeout to CodeDeploy task

### DIFF
--- a/Tasks/CodeDeployDeployApplication/helpers/DeployApplicationTaskParameters.ts
+++ b/Tasks/CodeDeployDeployApplication/helpers/DeployApplicationTaskParameters.ts
@@ -27,6 +27,8 @@ export class TaskParameters extends sdkutils.AWSTaskParametersBase {
     public updateOutdatedInstancesOnly: boolean;
     public ignoreApplicationStopFailures: boolean;
     public outputVariable: string;
+    public timeoutInMins: number;
+    public static defaultTimeoutInMins: number = 30;
 
     constructor() {
         super();
@@ -52,6 +54,7 @@ export class TaskParameters extends sdkutils.AWSTaskParametersBase {
             this.updateOutdatedInstancesOnly = tl.getBoolInput('updateOutdatedInstancesOnly', false);
             this.ignoreApplicationStopFailures = tl.getBoolInput('ignoreApplicationStopFailures', false);
             this.outputVariable = tl.getInput('outputVariable', false);
+            this.timeoutInMins = Number(tl.getInput('timeoutInMins', false)) || 30;
         } catch (error) {
             throw new Error(error.message);
         }

--- a/Tasks/CodeDeployDeployApplication/task.json
+++ b/Tasks/CodeDeployDeployApplication/task.json
@@ -152,6 +152,15 @@
             "groupName": "advanced"
         },
         {
+            "name": "timeoutInMins",
+            "type": "string",
+            "label": "Max Timout (minutes)",
+            "defaultValue": "30",
+            "groupName": "advanced",
+            "helpMarkDown": "Maximum time, specified in minutes, that the task should wait for the deployment to complete. By default a maximum of 30 minutes is used.",
+            "required": false
+        },
+        {
             "name": "outputVariable",
             "type": "string",
             "label": "Output Variable",
@@ -204,6 +213,7 @@
         "ZipError": "Zip Error: %s",
         "RevisionBundleDoesNotExist": "Archive with key %s does not exist in the Amazon S3 bucket %s",
         "DeletingUploadedBundle": "Deleting uploaded bundle %s created by task",
-        "TaskCompleted": "Deployment to application %s completed"
+        "TaskCompleted": "Deployment to application %s completed",
+        "SettingCustomTimeout": "Setting the custom timout to %s minute(s)"
     }
 }


### PR DESCRIPTION
Hi,

This PR is related to issue #87 where the CodeDeploy.waitFor function times out after 30 minutes in 'AWS CodeDeploy Application Deployment' VSTS task.

I have updated the VSTS task in accordance with the code snippets provided in PR #88 comments. The default value for the timeout parameter is set to 30 minutes. The updated VSTS task has been tested by @kevbite who initially reported issue #87.