### PR TITLE
Fix user agent check in testing, modify user agent to make it more consistent

### DIFF
--- a/Tasks/Common/sdkutils.ts
+++ b/Tasks/Common/sdkutils.ts
@@ -103,14 +103,7 @@ export abstract class SdkUtils {
                         if (
                             agent.startsWith(`${this.userAgentPrefix}/`) &&
                             agent.includes(`${this.userAgentSuffix}`) &&
-                            agent.includes(`${process.env.AGENT_VERSION}`) &&
-                            agent.endsWith(
-                                `${
-                                    (JSON.parse(
-                                        fs.readFileSync(path.join(__dirname, 'task.json'), 'utf8')
-                                    ) as VSTSTaskManifest).name
-                                }`
-                            )
+                            agent.includes(`${process.env.AGENT_VERSION}`)
                         ) {
                             // Note: only displays if system.debug variable set true on the build
                             logger(`User-Agent ${agent} validated successfully`)

--- a/Tasks/Common/sdkutils.ts
+++ b/Tasks/Common/sdkutils.ts
@@ -16,7 +16,7 @@ import { format, parse } from 'url'
 export abstract class SdkUtils {
     private static readonly agentTempDirectoryVariable: string = 'Agent.TempDirectory'
     private static readonly userAgentPrefix: string = 'AWS-VSTS'
-    private static readonly userAgentSuffix: string = 'exec-env/VSTS'
+    private static readonly userAgentSuffix: string = 'exec-env/VSTS.'
     private static readonly userAgentHeader: string = 'User-Agent'
 
     // set on the integration test server so we validate the agent is set
@@ -42,9 +42,9 @@ export abstract class SdkUtils {
             const agentVersion = process.env.AGENT_VERSION
             const taskManifest = JSON.parse(fs.readFileSync(taskManifestFilePath, 'utf8')) as VSTSTaskManifest
             const version = taskManifest.version
-            const userAgentString = `${this.userAgentPrefix}/${version.Major}.${version.Minor}.${version.Patch} ${
+            const userAgentString = `${this.userAgentPrefix}/${version.Major}.${version.Minor}.${version.Patch}-${
                     this.userAgentSuffix
-                }${agentVersion}-${taskManifest.name}`
+                }${agentVersion}/${taskManifest.name}`
                 // tslint:disable-next-line:whitespace align
             ;((AWS as any).util as any).userAgent = () => {
                 return userAgentString

--- a/Tasks/Common/sdkutils.ts
+++ b/Tasks/Common/sdkutils.ts
@@ -102,7 +102,15 @@ export abstract class SdkUtils {
                         const agent: string = httpRequest.headers[this.userAgentHeader]
                         if (
                             agent.startsWith(`${this.userAgentPrefix}/`) &&
-                            agent.includes(`${this.userAgentSuffix}-`)
+                            agent.includes(`${this.userAgentSuffix}`) &&
+                            agent.includes(`${process.env.AGENT_VERSION}`) &&
+                            agent.endsWith(
+                                `${
+                                    (JSON.parse(
+                                        fs.readFileSync(path.join(__dirname, 'task.json'), 'utf8')
+                                    ) as VSTSTaskManifest).name
+                                }`
+                            )
                         ) {
                             // Note: only displays if system.debug variable set true on the build
                             logger(`User-Agent ${agent} validated successfully`)

--- a/Tasks/Common/sdkutils.ts
+++ b/Tasks/Common/sdkutils.ts
@@ -42,9 +42,9 @@ export abstract class SdkUtils {
             const agentVersion = process.env.AGENT_VERSION
             const taskManifest = JSON.parse(fs.readFileSync(taskManifestFilePath, 'utf8')) as VSTSTaskManifest
             const version = taskManifest.version
-            const userAgentString = `${this.userAgentPrefix}/${version.Major}.${version.Minor}.${version.Patch}-${
+            const userAgentString = `${this.userAgentPrefix}/${version.Major}.${version.Minor}.${version.Patch} ${
                     this.userAgentSuffix
-                }${agentVersion}/${taskManifest.name}`
+                }${agentVersion} ${taskManifest.name}`
                 // tslint:disable-next-line:whitespace align
             ;((AWS as any).util as any).userAgent = () => {
                 return userAgentString


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Added tests
-   [ ] Code cleanup

## Description

- Change the user agent to match the format like: "AWS-VSTS/1.1.30 exec-env/VSTS.2.144.2 CloudFormationCreateOrUpdateStack" unlike the previous format this only has one seperator (a space) instead of spaces and slashes
- Fix the test for user agent which makes our integration test server happy
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s), If Filed

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **README** document
-   [ ] I have read the **CONTRIBUTING** document
-   [ ] Local run of `npm run fullBuild` succeeds
-   [ ] I have run tslint against my changes using the root tslint.yaml
-   [ ] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] All new and existing tests passed
-   [ ] A short description of the change has been added to the **CHANGELOG** (CHANGELOG.md) if the change is feature related

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
