### PR TITLE
Fix issue #272 Stop printing the docker login command string

### DIFF
--- a/.changes/next-release/Bug Fix-6d54fb72-bdcb-4937-9b05-13c1a97fa57a.json
+++ b/.changes/next-release/Bug Fix-6d54fb72-bdcb-4937-9b05-13c1a97fa57a.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Fix issue #272 by no longer printing the command"
+}

--- a/Tasks/Common/dockerUtils.ts
+++ b/Tasks/Common/dockerUtils.ts
@@ -35,7 +35,12 @@ export async function locateDockerExecutable(): Promise<string> {
     return dockerPath
 }
 
-export async function runDockerCommand(dockerPath: string, command: string, args: string[]): Promise<void> {
+export async function runDockerCommand(
+    dockerPath: string,
+    command: string,
+    args: string[],
+    additionalCommandLineOptions?: any
+): Promise<void> {
     console.log(tl.loc('InvokingDockerCommand', dockerPath, command))
 
     const docker = tl.tool(dockerPath)
@@ -46,5 +51,5 @@ export async function runDockerCommand(dockerPath: string, command: string, args
     }
 
     // tslint:disable-next-line: no-unsafe-any
-    await docker.exec()
+    await docker.exec(additionalCommandLineOptions)
 }

--- a/Tasks/Common/dockerUtils.ts
+++ b/Tasks/Common/dockerUtils.ts
@@ -7,7 +7,12 @@ import tl = require('vsts-task-lib/task')
 
 export interface DockerHandler {
     locateDockerExecutable(): Promise<string>
-    runDockerCommand(dockerPath: string, command: string, args: string[]): Promise<void>
+    runDockerCommand(
+        dockerPath: string,
+        command: string,
+        args: string[],
+        additionalCommandLineOptions?: any
+    ): Promise<void>
 }
 
 export async function locateDockerExecutable(): Promise<string> {

--- a/Tasks/ECRPushImage/TaskOperations.ts
+++ b/Tasks/ECRPushImage/TaskOperations.ts
@@ -106,13 +106,12 @@ export class TaskOperations {
             .decode(encodedAuthToken)
             .trim()
             .split(':')
-        await this.dockerHandler.runDockerCommand(this.dockerPath, 'login', [
-            '-u',
-            tokens[0],
-            '-p',
-            tokens[1],
-            endpoint
-        ])
+        await this.dockerHandler.runDockerCommand(
+            this.dockerPath,
+            'login',
+            ['-u', tokens[0], '-p', tokens[1], endpoint],
+            { silent: true }
+        )
     }
 
     private async tagImage(sourceImageRef: string, imageTag: string): Promise<void> {


### PR DESCRIPTION
## Description

Stop printing the docker login command string as it has a token in it.

## Motivation

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s), If Filed

#272

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **README** document
-   [ ] I have read the **CONTRIBUTING** document
-   [ ] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
