### PR TITLE
Store commit hash in vsix

### DIFF
--- a/build-scripts/packageExtension.js
+++ b/build-scripts/packageExtension.js
@@ -30,6 +30,17 @@ function package(options) {
     fs.copySync(path.join(folders.repoRoot, '_build', manifestFile), path.join(folders.packageRoot, manifestFile), {
         overwrite: true
     })
+    // Do a best effort job of generating a git hash and putting it into the package
+    try {
+        let response = shell.exec('git rev-parse HEAD')
+        if (response.code !== 0) {
+            console.log('Warning: unable to run git rev-parse to get commit hash!')
+        } else {
+            fs.outputFileSync(path.join(folders.packageRoot, '.gitcommit'), response.stdout)
+        }
+    } catch (e) {
+        console.log('Getting commit hash failed ' + e)
+    }
 
     // stage manifest images
     fs.copySync(path.join(folders.repoRoot, 'images'), path.join(folders.packageRoot, 'images'), { overwrite: true })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, we cannot tell what commit a vsix is built from. By adding a .gitcommit file in the package, it makes it possible to see what commit created what vsix.
<!--- Describe your changes in detail -->

## Motivation

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s), If Filed

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **README** document
-   [ ] I have read the **CONTRIBUTING** document
-   [ ] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
