### PR TITLE
ECRPullImage Task: Add output variable

### DIFF
--- a/.changes/next-release/Feature-f92007af-2cff-403e-965f-7bd63eb7025a.json
+++ b/.changes/next-release/Feature-f92007af-2cff-403e-965f-7bd63eb7025a.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Output image tag from ECR Pull task"
+}

--- a/.changes/next-release/Feature-f92007af-2cff-403e-965f-7bd63eb7025a.json
+++ b/.changes/next-release/Feature-f92007af-2cff-403e-965f-7bd63eb7025a.json
@@ -1,4 +1,4 @@
 {
     "type": "Feature",
-    "description": "Output image tag from ECR Pull task"
+    "description": "Output image tag from ECR Pull task per issue #315"
 }

--- a/Tasks/ECRPullImage/TaskOperations.ts
+++ b/Tasks/ECRPullImage/TaskOperations.ts
@@ -59,6 +59,11 @@ export class TaskOperations {
         await loginToRegistry(this.dockerHandler, this.dockerPath, authToken, proxyEndpoint)
         await this.pullImageFromECR(targetImageRef)
 
+        if (this.taskParameters.outputVariable) {
+            console.log(tl.loc('SettingOutputVariable', this.taskParameters.outputVariable, targetImageRef))
+            tl.setVariable(this.taskParameters.outputVariable, targetImageRef)
+        }
+
         console.log(tl.loc('TaskCompleted'))
     }
 

--- a/Tasks/ECRPullImage/TaskParameters.ts
+++ b/Tasks/ECRPullImage/TaskParameters.ts
@@ -15,6 +15,7 @@ export interface TaskParameters {
     imageTag: string
     imageDigest: string
     repository: string
+    outputVariable: string
 }
 
 export function buildTaskParameters(): TaskParameters {
@@ -23,7 +24,8 @@ export function buildTaskParameters(): TaskParameters {
         imageSource: getInputRequired('imageSource'),
         repository: getInputRequired('repository'),
         imageTag: getInputOrEmpty('imageTag'),
-        imageDigest: getInputOrEmpty('imageDigest')
+        imageDigest: getInputOrEmpty('imageDigest'),
+        outputVariable: getInputOrEmpty('outputVariable')
     }
 
     return parameters

--- a/Tasks/ECRPullImage/task.json
+++ b/Tasks/ECRPullImage/task.json
@@ -85,6 +85,15 @@
             "visibleRule": "imageSource = imagedigest"
         },
         {
+            "name": "outputVariable",
+            "type": "string",
+            "label": "Image Tag Output Variable",
+            "defaultValue": "",
+            "groupName": "output",
+            "helpMarkDown": "The name of the variable that will contain the tag of the image pulled from ECR. The image tag will be of the form *aws_account_id.dkr.ecr.region.amazonaws.com/imagename*, where **imagename** is in the format *repositoryname[:tag]*",
+            "required": false
+        },
+        {
             "name": "logRequest",
             "type": "boolean",
             "label": "Log Request",
@@ -117,6 +126,7 @@
         "RequestingAuthToken": "Obtaining authentication token for ECR login",
         "FailureToObtainAuthToken": "Failed to obtain auth token!",
         "NoValidEndpoint": "Failed to get endpoint of repository %s. Check your credentials and if the endpoint exists!",
-        "TaskCompleted": "Successfully completed sending the message"
+        "TaskCompleted": "Successfully completed sending the message",
+        "SettingOutputVariable": "Setting output variable %s with the pushed image tag %s"
     }
 }

--- a/tests/taskTests/ecrPullImage/ecrPullImage-test.ts
+++ b/tests/taskTests/ecrPullImage/ecrPullImage-test.ts
@@ -19,7 +19,8 @@ const defaultTaskParameters: TaskParameters = {
     imageSource: '',
     imageTag: '',
     imageDigest: '',
-    repository: ''
+    repository: '',
+    outputVariable: ''
 }
 
 const defaultDocker: DockerHandler = {


### PR DESCRIPTION
## Description

Adds an output variable to the ECRPullImage task. If an output variable name is provided, the variable will be set to the full image tag that is pulled from the repository.

This change follows the pattern in the ECRPushImage task.

## Motivation

The image name is passed as an input argument, but the pulled image is prefixed with the ECR endpoint. Outputting the image tag as pulled from ECR allows subsequent tasks to easily reference the image without reconstructing the tag from the endpoint and image name.

## Issues

See #315 

## Testing

Not tested locally.

## Checklist

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
