### PR TITLE
Update Lambda runtime list

### DIFF
--- a/Tasks/LambdaDeployFunction/task.json
+++ b/Tasks/LambdaDeployFunction/task.json
@@ -99,11 +99,13 @@
                 "dotnetcore2.1": "dotnetcore2.1",
                 "go1.x": "go1.x",
                 "java8": "java8",
-                "nodejs8.10": "nodejs8.10",
+                "java11": "java11",
                 "nodejs10.x": "nodejs10.x",
+                "nodejs12.x": "nodejs12.x",
                 "python2.7": "python2.7",
                 "python3.6": "python3.6",
                 "python3.7": "python3.7",
+                "python3.8": "python3.8",
                 "ruby2.5": "ruby2.5"
             },
             "properties": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove `nodejs8.10` as updates are disabled as of today
- Add `nodejs12.x` and `python3.8`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
