### PR TITLE
Add assume role support to AWS CLI task (issue #291)

### DIFF
--- a/.changes/next-release/Bug Fix-0d3a4598-3ce4-49c2-b03b-5cb8ad27fe04.json
+++ b/.changes/next-release/Bug Fix-0d3a4598-3ce4-49c2-b03b-5cb8ad27fe04.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Fix issue #291 AWS CLI did not assume role if it was set in the service connection"
+}

--- a/Tasks/AWSCLI/TaskOperations.ts
+++ b/Tasks/AWSCLI/TaskOperations.ts
@@ -42,12 +42,16 @@ export class TaskOperations {
     private async configureAwsCli() {
         const env = process.env
 
-        const credentials = await getCredentials(this.taskParameters.awsConnectionParameters)
+        const connectionParams = this.taskParameters.awsConnectionParameters
+        const credentials = await getCredentials(connectionParams)
         if (credentials) {
             await credentials.getPromise()
             tl.debug('configure credentials into environment variables')
             env.AWS_ACCESS_KEY_ID = credentials.accessKeyId
             env.AWS_SECRET_ACCESS_KEY = credentials.secretAccessKey
+            if (connectionParams.AssumeRoleARN) {
+                env.AWS_ROLE_ARN = connectionParams.AssumeRoleARN
+            }
             if (credentials.sessionToken) {
                 env.AWS_SESSION_TOKEN = credentials.sessionToken
             }

--- a/tslint.yaml
+++ b/tslint.yaml
@@ -99,9 +99,6 @@ rules:
         options:
             - spaces
             - 4
-    max-line-length:
-        options:
-            - 120
     no-duplicate-imports: true
     prefer-const: true
     prefer-readonly: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

AWS CLI did not assume role before. Add it to the task if it exists.

## Related Issue(s), If Filed

#291

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
