### PR TITLE
Fix Lambda invoke with JSON payloads

### DIFF
--- a/.changes/next-release/Bug Fix-69d2c958-09df-464d-b3c6-867d6b612a41.json
+++ b/.changes/next-release/Bug Fix-69d2c958-09df-464d-b3c6-867d6b612a41.json
@@ -1,4 +1,4 @@
 {
     "type": "Bug Fix",
-    "description": "Fix corrupting lambda invokations with JSON payloads"
+    "description": "Fix corrupting lambda invocations with JSON payloads"
 }

--- a/.changes/next-release/Bug Fix-69d2c958-09df-464d-b3c6-867d6b612a41.json
+++ b/.changes/next-release/Bug Fix-69d2c958-09df-464d-b3c6-867d6b612a41.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Fix corrupting lambda invokations with JSON payloads"
+}

--- a/Tasks/LambdaInvokeFunction/TaskOperations.ts
+++ b/Tasks/LambdaInvokeFunction/TaskOperations.ts
@@ -19,7 +19,7 @@ export class TaskOperations {
             FunctionName: this.taskParameters.functionName
         }
         if (this.taskParameters.payload) {
-            params.Payload = JSON.stringify(this.taskParameters.payload)
+            params.Payload = Buffer.from(this.taskParameters.payload)
         }
         if (this.taskParameters.invocationType) {
             params.InvocationType = this.taskParameters.invocationType

--- a/tests/taskTests/lambdaInvoke/lambdaInvoke-test.ts
+++ b/tests/taskTests/lambdaInvoke/lambdaInvoke-test.ts
@@ -82,4 +82,23 @@ describe('Lambda Invoke', () => {
         expect(lambda.invoke).toBeCalledTimes(2)
         expect(lambda.getFunctionConfiguration).toBeCalledTimes(2)
     })
+
+    test('Handles json property', async () => {
+        expect.assertions(3)
+        const taskParameters = { ...baseTaskParameters }
+        const payload = '{"key": "value"}'
+        taskParameters.payload = payload
+        const lambda = new Lambda() as any
+        lambda.getFunctionConfiguration = jest.fn(() => getFunctionSucceeds)
+        lambda.invoke = jest.fn(params => {
+            console.log(params)
+            expect(params.Payload.toString('utf8')).toBe(payload)
+
+            return invokeLambdaSucceeds
+        })
+        const taskOperations = new TaskOperations(lambda, taskParameters)
+        await taskOperations.execute()
+        expect(lambda.invoke).toBeCalledTimes(1)
+        expect(lambda.getFunctionConfiguration).toBeCalledTimes(1)
+    })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Lambda payloads were getting JSON.stringified which broke lambda invoke of a json payload without workarounds. the Javascript SDK [supports using a buffer](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#invoke-property), so use that

## Related Issue(s), If Filed

#330 , #137

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
