### PR TITLE
Added .NET Core 3.1 to Lambda runtimes

### DIFF
--- a/.changes/next-release/Feature-897c0711-a74f-4e1c-b2e0-bea6161cfe6f.json
+++ b/.changes/next-release/Feature-897c0711-a74f-4e1c-b2e0-bea6161cfe6f.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Added .NET Core 3.1 to Lambda runtimes"
+}

--- a/Tasks/LambdaDeployFunction/task.json
+++ b/Tasks/LambdaDeployFunction/task.json
@@ -96,6 +96,7 @@
             "helpMarkDown": "The runtime environment for the Lambda function you are uploading. The list of runtimes available in the pick list are those known at the time this version of the tools was released. To use a runtime not shown in the list simply enter the runtime identifier in the field.",
             "options": {
                 "provided": "provided",
+                "dotnetcore3.1": "dotnetcore3.1",
                 "dotnetcore2.1": "dotnetcore2.1",
                 "go1.x": "go1.x",
                 "java8": "java8",


### PR DESCRIPTION
## Description

Adding .NET Core 3.1 to the Lambda deploy task.

## Motivation

To deploy functions with .NET Core 3.1.

## Related Issue(s), If Filed

N/A

## Testing

Checked Lambda documentation for correct runtime identifier.

## Checklist

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
