### PR TITLE
add .json to list of knownMimeTypes

### DIFF
--- a/.changes/next-release/Bug Fix-f01c352e-3d56-40d3-bd44-a9a84917d7f7.json
+++ b/.changes/next-release/Bug Fix-f01c352e-3d56-40d3-bd44-a9a84917d7f7.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "add .json to list of knownMimeTypes"
+}

--- a/Tasks/Common/s3.ts
+++ b/Tasks/Common/s3.ts
@@ -65,6 +65,7 @@ export const knownMimeTypes: Map<string, string> = new Map<string, string>([
     ['.jpeg', 'image/jpeg'],
     ['.jpg', 'image/jpeg'],
     ['.js', 'application/x-javascript'],
+    ['.json', 'application/json'],
     ['.kar', 'audio/midi'],
     ['.latex', 'application/x-latex'],
     ['.lha', 'application/octet-stream'],


### PR DESCRIPTION
Added .json to list of knownMimeTypes

## Description

1 liner to add json to the list.
EDIT: possibly json was left out as the correct mime type for jsonp is application/javascript?

## Motivation

Currently when using the s3 upload task, json files are getting `Content-Type: application/octet-stream`. This is surely wrong, and should be `application/json`.

## Related Issue(s), If Filed

#341 

## Testing

I didn't do any testing. And I am not sure if this is considered a breaking change, in case the existing installs are someone relying on the current behaviour. But the current behaviour is surely broken...

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
